### PR TITLE
Render correct spacing when headline is present

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -14,11 +14,7 @@
   }
 }
 
-// Tracks headline presence to manage spacing between headline and connections
-#let headline-rendered = state("headline-rendered", false)
-
 #let headline(headline) = {
-  headline-rendered.update(true)
   metadata("skip-content-area")
   context {
     let config = rendercv-config.get()
@@ -28,6 +24,7 @@
     let colors-headline = config.at("colors-headline")
     let typography-small-caps-headline = config.at("typography-small-caps-headline")
     let header-alignment = config.at("header-alignment")
+    let header-space-below-headline = config.at("header-space-below-headline")
     set text(
       fill: colors-headline,
       font: typography-font-family-headline,
@@ -55,7 +52,6 @@
     let page-left-margin = config.at("page-left-margin")
     let page-right-margin = config.at("page-right-margin")
     let header-space-below-connections = config.at("header-space-below-connections")
-    let header-space-below-name = config.at("header-space-below-name")
     let section-titles-space-above = config.at("section-titles-space-above")
     let colors-connections = config.at("colors-connections")
     let typography-font-family-connections = config.at("typography-font-family-connections")
@@ -63,7 +59,6 @@
     let typography-small-caps-connections = config.at("typography-small-caps-connections")
     let typography-bold-connections = config.at("typography-bold-connections")
     let header-alignment = config.at("header-alignment")
-    let has-headline = headline-rendered.get()
 
     set par(spacing: 0pt, leading: typography-line-spacing * 1.7, justify: false)
     set text(
@@ -81,7 +76,6 @@
     let separator-width = (
       measure(header-connections-separator).width + header-connections-space-between-connections
     )
-    if not has-headline { v(header-space-below-name, weak: true) }
     if connections.pos().len() > 0 {
       set align(header-alignment)
       box(


### PR DESCRIPTION
Added a state tracker to detect headlines. Headline now triggers header-space-below-headline and Connections only adds header-space-below-name as a fallback when the headline is missing.