### PR TITLE
Fixes #6: Change logic for detecting empty second line in education entry

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -352,7 +352,7 @@
         main-column
       },
       date-and-location-column,
-      main-column-second-row: if main-column-second-row != none {
+      main-column-second-row: if main-column-second-row.fields().len() > 0 {
         [
           #block(
             main-column-second-row,

--- a/lib.typ
+++ b/lib.typ
@@ -352,7 +352,7 @@
         main-column
       },
       date-and-location-column,
-      main-column-second-row: if main-column-second-row.fields().len() > 0 {
+      main-column-second-row: if main-column-second-row != none and repr(main-column-second-row) != "[ ]" {
         [
           #block(
             main-column-second-row,


### PR DESCRIPTION
Details in issue #6.

It might be a good idea to implement this after adding the option to adjust spacing between education entries specifically, as explained in the first comment of the issue.